### PR TITLE
[User Story] Modify parking spot and locker information

### DIFF
--- a/src/app/api/property/CondoFileAPI.ts
+++ b/src/app/api/property/CondoFileAPI.ts
@@ -14,7 +14,7 @@ export const uploadCondoFile = async (file: any, fileName: string) => {
 }
 
 export const submitCondoFile = async (file: any) => {
-    console.log(file)
+    if(file.id === undefined) delete file.id
     supabase
         .from('CondoFile')
         .upsert([file])

--- a/src/app/api/property/ParkingLockerAPI.ts
+++ b/src/app/api/property/ParkingLockerAPI.ts
@@ -1,0 +1,60 @@
+import connection from "@/app/api/supabase/SupabaseContextProvider";
+
+const supabase = connection;
+
+export const deleteParkingLocker = async (id: any, type: 'PARKING' | 'LOCKER') => {
+    const {data, error} = await supabase
+        .from(type == 'PARKING' ? 'ParkingSpot' : 'Locker')
+        .delete()
+        .eq('id', id)
+    return {data, error}
+}
+
+export const createParkingLocker = async (property_id: number, type: 'PARKING' | 'LOCKER') => {
+    const {data, error} = await supabase
+        .from(type == 'PARKING' ? 'ParkingSpot' : 'Locker')
+        .insert([{property_id}])
+    return {data, error}
+}
+
+export const getParkingLockerListFromProperty = async (id: any, type: 'PARKING' | 'LOCKER') => {
+    const {data, error} = await supabase
+        .from(type == 'PARKING' ? 'ParkingSpot' : 'Locker')
+        .select('*')
+        .eq('property_id', id)
+        .order('id', {ascending: true})
+    return {data, error}
+}
+
+export const freeParkingLockerById = async (item_id: number, type: 'PARKING' | 'LOCKER') => {
+    const {data, error} = await supabase
+        .from(type == 'PARKING' ? 'ParkingSpot' : 'Locker')
+        .update({unit_id: null})
+        .eq('id', item_id)
+    return {data, error}
+}
+
+export const allocateParkingLockerById = async (item_id:number, unit_id: number, type: 'PARKING' | 'LOCKER') => {
+    const {data, error} = await supabase
+        .from(type == 'PARKING' ? 'ParkingSpot' : 'Locker')
+        .update({unit_id: unit_id})
+        .eq('id', item_id)
+    return {data, error}
+}
+
+export const getHighestParkingLockerId = async (type: 'PARKING' | 'LOCKER') => {
+    const {data, error} = await supabase
+        .from(type == 'PARKING' ? 'ParkingSpot' : 'Locker')
+        .select('id')
+        .order('id', {ascending: false})
+        .limit(1)
+    return {data, error}
+}
+
+export const updateParkingLockerFee = async (id: number, fee: number, type: 'PARKING' | 'LOCKER') => {
+    const {data, error} = await supabase
+        .from(type == 'PARKING' ? 'ParkingSpot' : 'Locker')
+        .update({fee})
+        .eq('id', id)
+    return {data, error}
+}

--- a/src/app/api/property/PropertyAPI.ts
+++ b/src/app/api/property/PropertyAPI.ts
@@ -6,9 +6,10 @@ const supabase = connection;
 export const getPropertiesFromCompany = async (id: any) => {
     const {data, error} = await supabase
         .from('Property')
-        .select('*, units:CondoUnit(*, files:CondoFile(*))')
+        .select('*, units:CondoUnit(*, files:CondoFile(*)), parking_spots:ParkingSpot(*), lockers:Locker(*)')
         .eq('company_id', id)
         .order('name', {ascending: true})
+
     return {data, error}
 }
 

--- a/src/app/components/dashboard/ActionButton.tsx
+++ b/src/app/components/dashboard/ActionButton.tsx
@@ -9,7 +9,7 @@ function ActionButton(props: ActionButtonProps) {
     return (
         <button
             onClick={props.onClick}
-            className={"flex items-center justify-center py-1 px-3 mx-auto bg-blue-500 text-white text-sm rounded-md"}
+            className={"flex items-center justify-center py-1 px-3 mx-auto bg-blue-500 hover:bg-blue-700 text-white text-sm rounded-md"}
         >
             {props.title}
         </button>

--- a/src/app/components/dashboard/ParkingLockerView.tsx
+++ b/src/app/components/dashboard/ParkingLockerView.tsx
@@ -1,0 +1,279 @@
+import React, {useEffect} from 'react';
+import PopupPanel from "@/app/components/dashboard/PopupPanel";
+import DashboardTable from "@/app/components/dashboard/DashboardTable";
+import {
+    allocateParkingLockerById,
+    createParkingLocker,
+    deleteParkingLocker,
+    freeParkingLockerById, getHighestParkingLockerId, updateParkingLockerFee
+} from "@/app/api/property/ParkingLockerAPI";
+
+interface ParkingLockerViewProps {
+    type: 'PARKING' | 'LOCKER';
+    view: 'PUBLIC' | 'COMPANY';
+    from: 'PROPERTY' | 'CONDO';
+    selectedItem: any;
+    isVisible: boolean;
+    setIsVisible: (value: boolean) => void;
+    items: any[];
+}
+
+function ParkingLockerView(props: ParkingLockerViewProps) {
+    const {
+        isVisible, setIsVisible,
+        type,
+        view,
+        from,
+        items,
+        selectedItem
+    } = props;
+
+    const [filteredItems, setFilteredItems] = React.useState<any[]>([]);
+    const filteredItemsRef = React.useRef(filteredItems);
+    const [popupTile, setPopupTitle] = React.useState<string>('');
+    const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
+    const [itemsToAdd, setItemsToAdd] = React.useState<{[key: number]: number}>({});
+    const [itemsToEdit, setItemsToEdit] = React.useState<{[key: number]: number}>({});
+    const itemsToDeleteRef = React.useRef(selectedItems);
+
+    const tableHeaders = [
+        {name: type == 'PARKING' ? 'Parking ID' : 'Locker ID', key: 'id_col'},
+        {name: type == 'PARKING' ? 'Parking Fee' : 'Locker Fee', key: 'fee_col'},
+        {name: "Status", key: "status"},
+    ]
+
+    useEffect(() => {
+        filteredItemsRef.current = filteredItems;
+    }, [filteredItems]);
+
+    useEffect(() => {
+        itemsToDeleteRef.current = selectedItems;
+    }, [selectedItems]);
+
+
+    const saveChangesFromProperty = async () => {
+        for (let i = 0; i < Object.keys(itemsToAdd).length; i++) {
+            await createParkingLocker(selectedItem.id, type)
+        }
+        for (let i = 0; i < Object.keys(itemsToEdit).length; i++) {
+            await updateParkingLockerFee(parseInt(Object.keys(itemsToEdit)[i]), itemsToEdit[parseInt(Object.keys(itemsToEdit)[i])], type)
+        }
+        window.location.reload()
+    }
+
+    const saveChangesFromUnit = async () => {
+        let previouslySelectedItems = items.reduce((acc, item) => {
+            if (item.unit_id == selectedItem.id) {
+                acc.push(item.id)
+            }
+            return acc
+        }, [])
+        // An item is freed if it was previously selected but not selected now
+        let itemsToFree = previouslySelectedItems.filter((item: number) => !itemsToDeleteRef.current.includes(item))
+        // An item is allocated if it was not previously selected but selected now
+        let itemsToAllocate = itemsToDeleteRef.current.filter((item: number) => !previouslySelectedItems.includes(item))
+        console.log("Items to allocate: ", itemsToAllocate)
+        for (let i = 0; i < itemsToAllocate.length; i++) {
+            await allocateParkingLockerById(itemsToAllocate[i], selectedItem.id, type)
+        }
+        for (let i = 0; i < itemsToFree.length; i++) {
+            await freeParkingLockerById(itemsToFree[i], type)
+        }
+        window.location.reload()
+    }
+    const toggleItemToDelete = (id: number) => {
+        setSelectedItems(prevItemsToDelete => {
+            if (prevItemsToDelete.includes(id)) {
+                // If the item is already selected, remove it from the list
+                return prevItemsToDelete.filter(item_id => item_id !== id);
+            } else {
+                // If the item is not already selected, add it to the list
+                return [...prevItemsToDelete, id];
+            }
+        });
+    };
+
+    const addItem = async () => {
+        // Cannot add more items than the max count
+        if (items.length + Object.keys(itemsToAdd).length >= (type == 'PARKING' ? selectedItem.parking_count : selectedItem.locker_count)) {
+            return;
+        }
+        let newId = -1;
+        // If itemsToAdd is empty, get the highest id from the database
+        if (Object.keys(itemsToAdd).length == 0) {
+            const {data, error} = await getHighestParkingLockerId(type)
+            if(data) newId = data[0].id + 1;
+        } else {
+            let keys = Object.keys(itemsToAdd).map((key) => parseInt(key));
+            newId = Math.max(...keys) + 1;
+        }
+        if(newId != -1) setItemsToAdd(currentItemsToAdd => ({ ...currentItemsToAdd, [newId]: 0 }));
+    }
+
+    const deleteItems = async () => {
+        for (let i = 0; i < selectedItems.length; i++) {
+            await deleteParkingLocker(selectedItems[i], type)
+        }
+        window.location.reload()
+    }
+
+    const selectInitialItems = () => {
+        let itemsToSelect = items.reduce((acc, item) => {
+            if (item.unit_id == selectedItem.id) {
+                acc.push(item.id)
+            }
+            return acc
+        }, [])
+        setSelectedItems(itemsToSelect)
+    }
+
+    // On popup close, reset.
+    useEffect(() => {
+        if (!isVisible) {
+            setSelectedItems([])
+            setItemsToAdd({})
+            setItemsToEdit({})
+            setFilteredItems([])
+        }
+    }, [isVisible]);
+
+    useEffect(() => {
+        if(view == 'COMPANY' && from == 'CONDO') selectInitialItems()
+    }, [items]);
+
+    const isItemOccupiedByUnit = (id: number) => {
+        // The checkbox should be disabled if the item is already allocated to another unit
+        if(view == 'COMPANY' && from == 'CONDO') {
+            let item = items.find(item => item.id == id)
+            return item.unit_id && item.unit_id != selectedItem.id;
+        }
+        else return false
+    }
+
+    const updateFilteredItems = (list: any[]) => {
+        // concat list and itemsToAdd
+        list = list.concat(Object.keys(itemsToAdd).map((id) => {
+            return {id: parseInt(id), fee: itemsToAdd[parseInt(id)]}
+        }))
+        let filteredData = list.map((item) => {
+            return {
+                id: item.id,
+                id_col: view == 'COMPANY' ?
+                    <div className={"flex flex-row justify-between px-2"}>
+                        <input type="checkbox"
+                               onChange={() => toggleItemToDelete(item.id)}
+                               checked={selectedItems.includes(item.id)}
+                               disabled={isItemOccupiedByUnit(item.id)}
+                        />
+                        <div>{item.id}</div>
+                        <input
+                            className={"invisible"}
+                            type="checkbox"
+                        />
+                    </div> : item.id,
+                fee: item.fee,
+                fee_col: from == "PROPERTY" ?
+                    <input
+                        className="p-2 m-1 max-w-36 appearance-none border border-slate-300 focus:outline-slate-500 rounded-md text-center"
+                        key={`fee-${item.id}`}
+                        defaultValue={itemsToEdit[item.id] || item.fee}
+                        onBlur={(e) => {
+                            const newFee = parseFloat(e.target.value);
+                            setItemsToEdit(currentFees => ({ ...currentFees, [item.id]: newFee }));
+                        }}
+                        type="number" id="fee">
+                    </input> : item.fee,
+                status: item.unit_id ? 'Occupied' : 'Available'
+            }
+        })
+        filteredData.sort((a, b) => a.id - b.id)
+        setFilteredItems(filteredData)
+    }
+
+    useEffect(() => {
+        updateFilteredItems(items)
+        setPopupTitle(type == 'PARKING' ? 'Parking Spots: ' + selectedItem.name : 'Lockers: ' + selectedItem.name)
+    }, [items, selectedItems, itemsToEdit, itemsToAdd]);
+
+    const TableContainer = () => (
+        <div
+            className={"max-h-96 overflow-y-auto shadow-sm"}>
+            <DashboardTable
+                headers={tableHeaders}
+                items={filteredItems}
+            />
+        </div>
+    );
+
+    const TableEditorFromUnit = () => (
+        <div>
+            <div className={"p-1 flex justify-between"}>
+                <span className={"text-md font-medium text-slate-700"}>
+                    All {type == 'PARKING' ? 'Parking Spots' : 'Lockers'} from Property: {selectedItem.property?.name}
+                </span>
+            </div>
+            <TableContainer/>
+        </div>
+    )
+    const TableEditorFromProperty = () => (
+        <div className={""}>
+            <div className={"p-1 flex justify-between"}>
+                <span className={"text-md font-medium text-slate-700"}>
+                    Max {type == 'PARKING' ? 'Parking' : 'Locker'} Count: {type == "PARKING" ? selectedItem.parking_count : selectedItem.locker_count}</span>
+                <span>
+                    Current Count: {items.length + Object.keys(itemsToAdd).length}
+                </span>
+            </div>
+            <TableContainer/>
+            <div className={"mt-3 flex flex-row justify-between"}>
+                <button
+                    onClick={addItem}
+                    className={"py-1 px-3 bg-blue-500 hover:bg-blue-700 text-white text-sm rounded-md"}>
+                    Add {type == 'PARKING' ? 'Parking' : 'Locker'}
+                </button>
+                <button
+                    onClick={deleteItems}
+                    className={`py-1 px-3  text-white text-sm rounded-md ${selectedItems.length == 0 ? 'bg-gray-500 ' : 'bg-red-500 hover:bg-red-700'}`}
+                    disabled={selectedItems.length == 0}
+                >
+                    Delete Selected
+                </button>
+            </div>
+        </div>
+    );
+
+    return (
+        <>
+            {view == 'PUBLIC' && from == 'CONDO' && (
+                <PopupPanel
+                    title={popupTile}
+                    visible={isVisible}
+                    setVisible={setIsVisible}
+                    children={<TableContainer/>}
+                />)
+            }
+            {view == 'COMPANY' && from == 'CONDO' && (
+                <PopupPanel
+                    title={popupTile}
+                    visible={isVisible}
+                    setVisible={setIsVisible}
+                    children={<TableEditorFromUnit/>}
+                    buttonTitle={"Allocate " + (type == 'PARKING' ? 'Parking Spot' : 'Locker') + ' to Unit'}
+                    onClick={saveChangesFromUnit}
+                />)
+            }
+            {view == 'COMPANY' && from == 'PROPERTY' && (
+                <PopupPanel
+                    title={popupTile}
+                    visible={isVisible}
+                    setVisible={setIsVisible}
+                    children={<TableEditorFromProperty/>}
+                    buttonTitle={"Save Changes"}
+                    onClick={saveChangesFromProperty}
+                />)
+            }
+        </>
+    );
+}
+
+export default ParkingLockerView;

--- a/src/app/constants/types.ts
+++ b/src/app/constants/types.ts
@@ -22,6 +22,8 @@ export interface PropertyType {
     description: string;
     unit_count: number;
     units?: CondoUnitType[];
+    parking_spots?: ParkingSpotType[];
+    lockers?: LockerType[];
     parking_count: number;
     locker_count: number;
     company_id: string;

--- a/src/app/dashboard/properties/page.tsx
+++ b/src/app/dashboard/properties/page.tsx
@@ -11,13 +11,14 @@ import PopupPanel from "@/app/components/dashboard/PopupPanel";
 import ActionIcon from "@/app/components/dashboard/ActionIcon";
 import {PencilSquareIcon} from "@heroicons/react/24/outline";
 import PropertyFilesView from "@/app/dashboard/properties/PropertyFilesView";
+import ParkingLockerView from "@/app/components/dashboard/ParkingLockerView";
 
 const propertyTableHeaders = [
     {name: 'Property Name', key: 'name'},
     {name: 'Address', key: 'address'},
     {name: 'Unit Count', key: 'unit_count'},
-    {name: 'Parking Count', key: 'parking_count'},
-    {name: 'Locker Count', key: 'locker_count'},
+    {name: 'Parking Spots', key: 'parking_count'},
+    {name: 'Lockers', key: 'locker_count'},
     {name: 'Condo files', key: 'condo_files'},
     {name: 'Actions', key: 'edit'},
 ]
@@ -31,8 +32,13 @@ function Page() {
     const [selectedProperty, setSelectedProperty] = React.useState<PropertyType>();
     const [newPropertyProfile, setNewPropertyProfile] = React.useState<PropertyType>({} as PropertyType);
     const [formAction, setFormAction] = React.useState<'EDIT' | 'CREATE'>();
+
     const [viewFiles, setViewFiles] = React.useState<boolean>(false);
-    const [selectedPropertyFiles, setSelectedPropertyFiles] = React.useState<PropertyType>({} as PropertyType);
+    const [selectedPropertyView, setSelectedPropertyView] = React.useState<PropertyType>({} as PropertyType);
+
+    const [viewParkingLocker, setViewParkingLocker] = React.useState<boolean>(false);
+    const [parkingLockerView, setParkingLockerView] = React.useState<'PARKING' | 'LOCKER'>('PARKING');
+    const [parkingLockerList, setParkingLockerList] = React.useState<any[]>([]);
 
 
     const selectProperty = (property: PropertyType) => {
@@ -44,12 +50,19 @@ function Page() {
     }
 
     const viewPropertyFiles = (property: PropertyType) => {
-        setSelectedPropertyFiles(property)
+        setSelectedPropertyView(property)
         setViewFiles(true)
     }
 
     const submitNewProperty = () => {
         submitPropertyProfile(newPropertyProfile).catch(console.error)
+    }
+
+    const viewParkingLockerOnClick = (property: PropertyType, type: 'PARKING' | 'LOCKER') => {
+        setSelectedPropertyView(property)
+        setViewParkingLocker(true)
+        setParkingLockerView(type)
+        setParkingLockerList(type == 'PARKING' ? property.parking_spots || [] : property.lockers || [])
     }
 
     const fetchPropertyData = async () => {
@@ -72,9 +85,6 @@ function Page() {
     useEffect(() => {
         if(propertyData.length == 0) return;
         let filteredData = propertyData.map((property) => {
-            // property has a list of units, each unit has a list of files
-            // I need to get the count of all files in all condos
-            // make sure that it is TS compliant
             const fileCount = property.units?.reduce((acc: number, unit) => {
                 return acc + (unit.files ? unit.files.length : 0);
             }, 0) || 0;
@@ -82,9 +92,9 @@ function Page() {
                 id: property.id,
                 name: property.name,
                 address: property.address,
-                unit_count: property.unit_count,
-                parking_count: property.parking_count,
-                locker_count: property.locker_count,
+                unit_count:  <span>{property.units?.length || 0}</span>,
+                parking_count: <ActionButton title={"View Parking (" + property.parking_spots?.length +")"} onClick={() => viewParkingLockerOnClick(property, 'PARKING')}/>,
+                locker_count: <ActionButton title={"View Lockers (" + property.lockers?.length +")"} onClick={() => viewParkingLockerOnClick(property, 'LOCKER')}/>,
                 condo_files: <ActionButton title={"View Files (" + fileCount + ")"} onClick={() => viewPropertyFiles(property)}/>,
                 edit: <ActionIcon Icon={PencilSquareIcon} onClick={() => selectProperty(property)}/>
             }
@@ -99,7 +109,20 @@ function Page() {
 
     return (
         <div className={"flex flex-col xl:flex-row sm:gap-[36px] gap-[28px]"}>
-            <PropertyFilesView isVisible={viewFiles} setIsVisible={setViewFiles} property={selectedPropertyFiles}/>
+            <PropertyFilesView
+                isVisible={viewFiles}
+                setIsVisible={setViewFiles}
+                property={selectedPropertyView}
+            />
+            <ParkingLockerView
+                type={parkingLockerView}
+                view={userType == 'COMPANY' ? 'COMPANY' : 'PUBLIC'}
+                from={'PROPERTY'}
+                isVisible={viewParkingLocker}
+                selectedItem={selectedPropertyView}
+                items={parkingLockerList}
+                setIsVisible={setViewParkingLocker}
+            />
             <div className={"min-w-0 max-w-fit"}>
                 <DashboardPanel
                     title={'My Properties'}

--- a/src/app/dashboard/units/page.tsx
+++ b/src/app/dashboard/units/page.tsx
@@ -158,7 +158,6 @@ function Page() {
     }, [userId]);
 
     useEffect(() => {
-        console.log(condoData)
         if(condoData.length == 0) return;
         let filteredData;
         if(userType === "COMPANY"){

--- a/src/app/dashboard/units/page.tsx
+++ b/src/app/dashboard/units/page.tsx
@@ -7,15 +7,19 @@ import {
     getPropertyIdByName, registerCondoUnitWithKey,
     submitCondoProfile, updateRegistrationKey
 } from "@/app/api/property/PropertyAPI";
-import {CondoFileType, CondoUnitType, PropertyType, UserType} from "@/app/constants/types";
+import {CondoUnitType, UserType} from "@/app/constants/types";
 import DashboardTable from "@/app/components/dashboard/DashboardTable";
 import CondoUnitInfo from "@/app/dashboard/units/CondoUnitInfo";
 import ActionButton from "@/app/components/dashboard/ActionButton";
 import KeyForm from "@/app/dashboard/units/KeyForm";
 import ActionIcon from "@/app/components/dashboard/ActionIcon";
 import {PencilSquareIcon} from "@heroicons/react/24/outline";
-import PropertyFilesView from "@/app/dashboard/properties/PropertyFilesView";
 import UnitsFilesView from "@/app/dashboard/units/UnitsFilesView";
+import ParkingLockerView from "@/app/components/dashboard/ParkingLockerView";
+import {
+    getParkingLockerListFromProperty as getLockerPropertyListFromProperty,
+    getParkingLockerListFromProperty
+} from "@/app/api/property/ParkingLockerAPI";
 
 const condoTableHeaders = [
     {name: 'Condo Name', key: 'name'},
@@ -24,8 +28,8 @@ const condoTableHeaders = [
     {name: 'Condo Number', key: 'number'},
     {name: 'Fee ($)', key: 'fee'},
     {name: 'Size (m²)', key: 'size'},
-    {name: 'Parking Spots', key: 'parking_spots_length'},
-    {name: 'Lockers', key: 'lockers_length'},
+    {name: 'Parking Spots', key: 'view_parking'},
+    {name: 'Lockers', key: 'view_lockers'},
     {name: 'View Files', key: 'view_files'},
 ]
 
@@ -36,8 +40,8 @@ const condoTableHeadersForCompany = [
     {name: 'Condo Number', key: 'number'},
     {name: 'Fee ($)', key: 'fee'},
     {name: 'Size (m²)', key: 'size'},
-    {name: 'Parking Spots', key: 'parking_spots_length'},
-    {name: 'Lockers', key: 'lockers_length'},
+    {name: 'Parking Spots', key: 'view_parking'},
+    {name: 'Lockers', key: 'view_lockers'},
     {name: 'View Files', key: 'view_files'},
     {name: 'Registration Key', key: 'registration_key'},
     {name: 'Occupied By', key: 'occupant'},
@@ -54,9 +58,13 @@ function Page() {
     const [newCondoProfile, setNewCondoProfile] = React.useState<CondoUnitType>({} as CondoUnitType);
     const [formAction, setFormAction] = React.useState<'EDIT' | 'CREATE'>();
     const [registrationKey, setRegistrationKey] = React.useState<string>("");
+
     const [viewFiles, setViewFiles] = React.useState<boolean>(false);
-    const [selectedCondoFiles, setSelectedCondoFiles] = React.useState<CondoUnitType>({} as CondoUnitType);
-    const [tooltipText, setTooltipText] = React.useState<string>('Click to copy key');
+    const [selectedCondoView, setSelectedCondoView] = React.useState<CondoUnitType>({} as CondoUnitType);
+
+    const [viewParkingLocker, setViewParkingLocker] = React.useState<boolean>(false);
+    const [parkingLockerView, setParkingLockerView] = React.useState<'PARKING' | 'LOCKER'>('PARKING');
+    const [parkingLockerList, setParkingLockerList] = React.useState<any[]>([]);
 
     const registerNewUnit = () => {
         setFormAction('CREATE')
@@ -70,9 +78,6 @@ function Page() {
         });
     };
 
-    useEffect(() => {
-        console.log(tooltipText)
-    }, [tooltipText]);
 
     const generateRegistrationKey = async (unit_id: any) => {
         const key = generateUUID();
@@ -109,8 +114,19 @@ function Page() {
     }
 
     const viewCondoFiles = (unit: CondoUnitType) => {
-        setSelectedCondoFiles(unit)
+        setSelectedCondoView(unit)
         setViewFiles(true)
+    }
+
+    const viewParkingLockerOnClick = async (unit: CondoUnitType, type: 'PARKING' | 'LOCKER') => {
+        setSelectedCondoView(unit)
+        setParkingLockerView(type)
+        setViewParkingLocker(true)
+        if(userType == UserType.COMPANY){
+            const {data, error} = await getParkingLockerListFromProperty(unit.property_id, type)
+            setParkingLockerList(data || [])
+        }
+        else setParkingLockerList(type === 'PARKING' ? unit.parking_spots : unit.lockers)
     }
 
     const fetchCondoData = async () => {
@@ -142,11 +158,11 @@ function Page() {
     }, [userId]);
 
     useEffect(() => {
+        console.log(condoData)
         if(condoData.length == 0) return;
         let filteredData;
         if(userType === "COMPANY"){
             filteredData = condoData.map((unit) => {
-                console.log(unit)
                 return {
                     id: unit.id,
                     name: unit.name,
@@ -156,20 +172,22 @@ function Page() {
                     description: unit.description,
                     fee: unit.fee,
                     size: unit.size,
-                    parking_spots_length: unit.parking_spots.length,
-                    lockers_length: unit.lockers.length,
+                    view_parking: <ActionButton title={`View Parking`} onClick={() => viewParkingLockerOnClick(unit, 'PARKING')}/>,
+                    view_lockers: <ActionButton title={`View Lockers`} onClick={() => viewParkingLockerOnClick(unit, 'LOCKER')}/>,
                     view_files: <ActionButton title={`View Files (${unit.files ? unit.files.length : 0})`} onClick={() => viewCondoFiles(unit)}/>,
                     registration_key:
                         <button
                             className={`${unit.registration_key ? 
-                                "flex items-center justify-center py-1 px-3 mx-auto bg-blue-500 text-white text-sm rounded-md" : 
+                                "flex items-center justify-center py-1 px-3 mx-auto bg-blue-500 hover:bg-blue-700 text-white text-sm rounded-md" : 
                                 "flex items-center justify-center py-1 px-3 mx-auto bg-gray-300 text-gray-500 text-sm rounded-md cursor-default"}`}
                             onClick={() => navigator.clipboard.writeText(unit.registration_key as string)}
                             disabled={!unit.registration_key}
                             title={unit.registration_key}>
                             {unit.registration_key ? "Copy Key" : "No Key"}
                         </button>,
-                    occupant: unit.occupant ? unit.occupant?.first_name + " " + unit.occupant?.last_name : "unoccupied",
+                    occupant: unit.occupant ?
+                        <div>{unit.occupant.first_name + " " + unit.occupant.last_name}</div> :
+                        <div className={"text-stone-600"}>Unoccupied</div>,
                     actions: (
                         <div className={"flex flex-row gap-4 py-2 px-3"}>
                             <ActionButton title={'Generate Key'} onClick={() => generateRegistrationKey(unit.id)}/>
@@ -189,8 +207,8 @@ function Page() {
                 description: unit.description,
                 fee: unit.fee,
                 size: unit.size,
-                parking_spots_length: unit.parking_spots?.length,
-                lockers_length: unit.lockers?.length,
+                view_parking: <ActionButton title={`View Parking (${unit.parking_spots.length})`} onClick={() => viewParkingLockerOnClick(unit, 'PARKING')}/>,
+                view_lockers: <ActionButton title={`View Lockers (${unit.lockers ? unit.lockers.length : 0})`} onClick={() => viewParkingLockerOnClick(unit, 'LOCKER')}/>,
                 view_files: <ActionButton title={'View Files'} onClick={() => viewCondoFiles(unit)}/>,
                 registration_key: unit.registration_key,
             }
@@ -201,7 +219,20 @@ function Page() {
 
     return (
         <div className={"flex flex-col xl:flex-row sm:gap-[36px] gap-[28px]"}>
-            <UnitsFilesView isVisible={viewFiles} setIsVisible={setViewFiles} condo={selectedCondoFiles}/>
+            <UnitsFilesView
+                isVisible={viewFiles}
+                setIsVisible={setViewFiles}
+                condo={selectedCondoView}
+            />
+            <ParkingLockerView
+                type={parkingLockerView}
+                isVisible={viewParkingLocker}
+                selectedItem={selectedCondoView}
+                setIsVisible={setViewParkingLocker}
+                items={parkingLockerList}
+                view={userType == UserType.COMPANY ? 'COMPANY' : 'PUBLIC'}
+                from={'CONDO'}
+            />
             <div className={"min-w-0 max-w-fit"}>
                 {(userType == UserType.RENTER || userType == UserType.OWNER) &&
                     <DashboardPanel

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,4 +18,9 @@
     tbody{
         @apply bg-white;
     }
+    input[type="number"]::-webkit-inner-spin-button,
+    input[type="number"]::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
 }


### PR DESCRIPTION
This PR references issues #15 and #16. Parking spots and lockers can now be created/edit/deleted.

They can also be associated to a property and unit. Its fee can change too. We can also view the status (occupied/available) for each item. 

closes #15, closes #16